### PR TITLE
Correct logic for filtering starred lines

### DIFF
--- a/make_fmhy_bookmarks.py
+++ b/make_fmhy_bookmarks.py
@@ -161,7 +161,7 @@ def alternativeWikiIndexing():
 wiki_adapted_md = '\n'.join(alternativeWikiIndexing())
 
 # Remove from the lines in wiki_adapted_md any line that doesnt contain the character `⭐` or '🌟'
-wiki_adapted_starred_only_md = '\n'.join([line for line in wiki_adapted_md.split('\n') if '⭐' or '🌟' in line])
+wiki_adapted_starred_only_md = '\n'.join([line for line in wiki_adapted_md.split('\n') if '⭐' in line or '🌟' in line])
 
 
 


### PR DESCRIPTION
This pull request includes a small but important change to the `make_fmhy_bookmarks.py` file. The change ensures that the filtering logic correctly identifies lines containing specific star characters. Fixes #8 

* [`make_fmhy_bookmarks.py`](diffhunk://#diff-087e786988f727d5ad18a3ca62e2c71b1264b3d1c95c19fcc756863240db1bf4L164-R164): Modified the filtering logic in the `alternativeWikiIndexing()` function to correctly check if a line contains either '⭐' or '🌟'.